### PR TITLE
Add GoogleOther

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -13,6 +13,7 @@ User-agent: cohere-ai
 User-agent: DataForSeoBot
 User-agent: FacebookBot
 User-agent: Google-Extended
+User-agent: GoogleOther
 User-agent: GPTBot
 User-agent: ImagesiftBot
 User-agent: magpie-crawler


### PR DESCRIPTION
Used by Google to crawl for internal research and development. It’s unknown what exactly this entails, but is a generic user agent that is used when no other appropriate user agent is available. Documentation available from Google: https://developers.google.com/search/docs/crawling-indexing/overview-google-crawlers