### PR TITLE
Remove potential false positives

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,8 +2,6 @@ User-agent: AdsBot-Google
 User-agent: Amazonbot
 User-agent: anthropic-ai
 User-agent: Applebot-Extended
-User-agent: AwarioRssBot
-User-agent: AwarioSmartBot
 User-agent: Bytespider
 User-agent: CCBot
 User-agent: ChatGPT-User
@@ -19,15 +17,11 @@ User-agent: GoogleOther
 User-agent: GPTBot
 User-agent: img2dataset
 User-agent: ImagesiftBot
-User-agent: magpie-crawler
-User-agent: Meltwater
 User-agent: omgili
 User-agent: omgilibot
 User-agent: peer39_crawler
 User-agent: peer39_crawler/1.0
 User-agent: PerplexityBot
-User-agent: PiplBot
-User-agent: scoop.it
 User-agent: Seekr
 User-agent: YouBot
 Disallow: /


### PR DESCRIPTION
I couldn’t seem to find evidence these bots are AI-related from their descriptions, nor are they so tagged over at Dark Visitors. They appear to be here for other reasons. Perhaps holdovers from a general-purpose `robots.txt`?

https://awario.com/bots.html
https://www.brandwatch.com/legal/magpie-crawler/
https://www.meltwater.com/en/products/media-monitoring
https://www.scoop.it/wp-static-pages/bots/
https://pipl.com/bot