### PR TITLE
Add `facebookexternalhit`

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -10,6 +10,7 @@ User-agent: cohere-ai
 User-agent: Diffbot
 User-agent: FacebookBot
 User-agent: FriendlyCrawler
+User-agent: facebookexternalhit
 User-agent: Google-Extended
 User-agent: GoogleOther
 User-agent: GoogleOther-Image

--- a/robots.txt
+++ b/robots.txt
@@ -18,6 +18,7 @@ User-agent: GoogleOther-Video
 User-agent: GPTBot
 User-agent: ImagesiftBot
 User-agent: img2dataset
+User-agent: meta-externalagent
 User-agent: OAI-SearchBot
 User-agent: omgili
 User-agent: omgilibot


### PR DESCRIPTION
The [advertised purpose](http://www.facebook.com/externalhit_uatext.php) for this crawler is no longer borne out by its actual behaviour, which now surpasses Google and Bing in its frequency and is often on a par with _eg_ Semrush. See, for instance, https://developers.facebook.com/community/threads/992798532416685/.

We also observed that it didn’t double-check `robots.txt` before starting another round of binge crawling.

All the signs point to its crawling on behalf of Meta’s recent AI efforts.

