### PR TITLE
Add `PetalBot` (and `facebookexternalhit`?)

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -10,6 +10,7 @@ User-agent: cohere-ai
 User-agent: Diffbot
 User-agent: FacebookBot
 User-agent: FriendlyCrawler
+User-agent: facebookexternalhit
 User-agent: Google-Extended
 User-agent: GoogleOther
 User-agent: GoogleOther-Image
@@ -22,6 +23,7 @@ User-agent: OAI-SearchBot
 User-agent: omgili
 User-agent: omgilibot
 User-agent: PerplexityBot
+User-agent: PetalBot
 User-agent: Scrapy
 User-agent: Timpibot
 User-agent: VelenPublicWebCrawler


### PR DESCRIPTION
`PetalBot` has been crawling very aggressively for some time and flouting `robots.txt` to boot. It’s finally made it to Cloudflare’s [verified AI bots category](https://radar.cloudflare.com/traffic/verified-bots), so I figure it’s time we added it too.

I’m also adding `facebookexternalhit` from #21 since it behaves exactly like `meta-externalagent`. There may be concerns that doing so would affect linking on FB, but that’s probably the very reason Meta is repurposing this particular UA for AI crawling – to prevent it being blocked as an AI bot. It’s your call when we should include this one.