### PR TITLE
Add ICC-Crawler

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -118,6 +118,13 @@
         "frequency": "No information.",
         "description": "Data is used to train current and future models, removed paywalled data, PII and data that violates the company's policies."
     },
+    "ICC-Crawler": {
+        "operator": "[NICT](https:\/\/nict.go.jp)",
+        "respect": "Yes",
+        "function": "Scrapes data to train and support AI technologies.",
+        "frequency": "No information.",
+        "description": "Use the collected data for artificial intelligence technologies; provide data to third parties, including commercial companies; those companies can use the data for their own business."
+    },
     "img2dataset": {
         "operator": "[img2dataset](https:\/\/github.com\/rom1504\/img2dataset)",
         "respect": "Unclear at this time.",


### PR DESCRIPTION
[ICC-Crawler](https://ucri.nict.go.jp/en/icccrawler.html) is a crawler operated by NICT, a Japanese independent administrative agency. Its operation policy was revised on July 11, 2024, adding the following to the purpose of data collection:

- Use the collected data for artificial intelligence technologies.
- Provide data to third parties, including commercial companies.
- Those companies can use the data for their own business.

This change was made in accordance with the Japanese government's AI policy. The government wants to support domestic IT companies to develop home-grown AI foundation models in Japan.