### PR TITLE
Add Cloudflares first-party scraper blocking to FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -23,6 +23,7 @@ That depends on your stack.
 - Netlify
   - [Blockin' bots on Netlify](https://www.jeremiak.com/blog/block-bots-netlify-edge-functions/) by Jeremia Kimelman
 - Cloudflare
+  - [Block AI bots, scrapers and crawlers with a single click](https://blog.cloudflare.com/declaring-your-aindependence-block-ai-bots-scrapers-and-crawlers-with-a-single-click) by Cloudflare
   - [I’m blocking AI crawlers](https://roelant.net/en/2024/im-blocking-ai-crawlers-part-2/) by Roelant
 
 ## Why should we block these crawlers?


### PR DESCRIPTION
Cloudflare now offers to block AI scrapers automatically, including ones which don't respect robots.txt.