### PR TITLE
only build on changes to robots.json

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+    paths:
+      - 'robots.json'
 
 jobs:
   ai-robots-txt:


### PR DESCRIPTION
This should avoid failed/unnecessary workflow runs when content *other* than `robots.json` gets updated (readme, faq, etc).