### PR TITLE
Improve main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,14 +20,7 @@ jobs:
       - run: |
           git config --global user.name "ai.robots.txt"
           git config --global user.email "ai.robots.txt@users.noreply.github.com"
-          git rm robots.txt
-          git rm table-of-bot-metrics.md
-          git add -A
-          git commit -m "Removing previously generated files"
-          git push
           php -f code/action.php
-          git config --global user.name "ai.robots.txt"
-          git config --global user.email "ai.robots.txt@users.noreply.github.com"
           git add -A
           if [ -n "${{ inputs.message }}" ]; then
             git commit -m "${{ inputs.message }}"


### PR DESCRIPTION
Currently, because the main workflow first removes the old files before committing new ones, the files are shown to be replaced _in toto_ in diffs. This is unnecessary because `file_put_contents` as used in `action.php` overwrites by default when the `FILE_APPEND` flag isn’t set.

This PR removes the redundant operation and allows a proper diff to be generated.