### PR TITLE
Add dataprovider

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -69,6 +69,13 @@
         "operator": "[Anthropic](https://www.anthropic.com)",
         "respect": "Unclear at this time."
     },
+    "Dataprovider": {
+        "description": "We’ve summarized the web, so you can find the exact information you need, whether it be technology trends, hosting, security risks, business information, website traffic or content.",
+        "frequency": "Unclear at this time.",
+        "function": "Aggregates structured web data for searching and AI model training.",
+        "operator": "[Dataprovider.com](https://www.dataprovider.com/)",
+        "respect": "[Yes](https://www.dataprovider.com/spider/)."
+    },
     "Diffbot": {
         "description": "Diffbot is an application used to parse web pages into structured data; this data is used for monitoring or AI model training.",
         "frequency": "Unclear at this time.",


### PR DESCRIPTION
[dataprovider](https://www.dataprovider.com/spider/) is a crawler owned by [Dataprovider.com](https://www.dataprovider.com/), which automatically indexes the entire web, making it available to their paying customers who can use that information however they see fit.

While their site doesn't explicitly mention AI, I think it's good to add, as it automatically collects as much information about every website it can and uses their “proprietary scores”. Right now, their only opt-out is by [going to a specific page on their website](https://www.dataprovider.com/spider/) and learning how to opt-out.