### PR TITLE
Create workflow to upload `robots.txt` file as release artefact

### DIFF
--- a/.github/workflows/upload-robots-txt-file-to-release.yml
+++ b/.github/workflows/upload-robots-txt-file-to-release.yml
@@ -1,0 +1,23 @@
+---
+
+name: "Upload robots.txt file to release"
+run-name: "Upload robots.txt file to release"
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  upload-robots-txt-file-to-release:
+    name: "Upload robots.txt file to release"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Upload"
+        run: gh --repo "${REPO}" release upload "${TAG}" robots.txt
+        env:
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/upload-robots-txt-file-to-release.yml
+++ b/.github/workflows/upload-robots-txt-file-to-release.yml
@@ -8,6 +8,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: write
+
 jobs:
   upload-robots-txt-file-to-release:
     name: "Upload robots.txt file to release"
@@ -19,5 +22,6 @@ jobs:
       - name: "Upload"
         run: gh --repo "${REPO}" release upload "${TAG}" robots.txt
         env:
+          GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
           TAG: ${{ github.event.release.tag_name }}

--- a/.github/workflows/upload-robots-txt-file-to-release.yml
+++ b/.github/workflows/upload-robots-txt-file-to-release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: "Checkout"
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
 
       - name: "Upload"
         run: gh --repo "${REPO}" release upload "${TAG}" robots.txt


### PR DESCRIPTION
This workflow uploads the `robots.txt` file as a release artefact when a release is published. This is essentially the same as downloading the automatic `Source code (zip)` file and extracting the `robots.txt` file from there, except that this is more direct.