### PR TITLE
Allow facebookexternalhit

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -104,13 +104,6 @@
         "frequency": "Up to 1 page per second",
         "description": "Officially used for training Meta \"speech recognition technology,\" unknown if used to train Meta AI specifically."
     },
-    "facebookexternalhit": {
-        "description": "Unclear at this time.",
-        "frequency": "Unclear at this time.",
-        "function": "No information.",
-        "operator": "Meta/Facebook",
-        "respect": "[Yes](https://developers.facebook.com/docs/sharing/bot/)"
-    },
     "FriendlyCrawler": {
         "description": "Unclear who the operator is; but data is used for training/machine learning.",
         "frequency": "Unclear at this time.",


### PR DESCRIPTION
At the time of writing, this crawler does not
appear to be for the purpose of AI.

See: https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/ (accessed on 19 November 2024).

Fixes https://github.com/ai-robots-txt/ai.robots.txt/issues/40