### PR TITLE
Restore attribution

### DIFF
--- a/.github/workflows/ai_robots_update.yml
+++ b/.github/workflows/ai_robots_update.yml
@@ -1,8 +1,5 @@
 name: Updates for AI robots files
 on:
-  push:
-    branches:
-    - "main"
   schedule:
     - cron: "0 0 * * *"
 
@@ -24,11 +21,10 @@ jobs:
           git --no-pager diff
           git add -A
           git diff --quiet && git diff --staged --quiet || (git commit -m "Update from Dark Visitors" && git push)
-          
-          echo "Updating robots.txt and table-of-bot-metrics.md if necessary ..."
-          python code/dark_visitors.py --convert
-          echo "... done."
-          git --no-pager diff
-          git add -A
-          git diff --quiet && git diff --staged --quiet || (git commit -m "Updated from new robots.json" && git push)
         shell: bash
+  call-main:
+    needs: dark-visitors
+    uses: ./.github/workflows/main.yml
+    secrets: inherit
+    with:
+      message: "Update from Dark Visitors"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,38 @@
+on:
+  workflow_call:
+    inputs:
+      message:
+        type: string
+        required: true
+        description: The message to commit
+  push:
+    paths:
+      - 'robots.json'
+    branches:
+      - "main"
+
+jobs:
+  ai-robots-txt:
+    runs-on: ubuntu-latest
+    name: ai-robots-txt
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - run: |
+          git config --global user.name "ai.robots.txt"
+          git config --global user.email "ai.robots.txt@users.noreply.github.com"
+          git log -1
+          git status
+          echo "Updating robots.txt and table-of-bot-metrics.md if necessary ..."
+          python code/dark_visitors.py --convert
+          echo "... done."
+          git --no-pager diff
+          git add -A
+          if [ -n "${{ inputs.message }}" ]; then
+            git commit -m "${{ inputs.message }}"
+          else
+            git commit -m "${{ github.event.head_commit.message }}"
+          fi
+          git push
+        shell: bash

--- a/code/tests.py
+++ b/code/tests.py
@@ -10,12 +10,12 @@ from dark_visitors import json_to_txt, json_to_table
 
 
 def test_robots_txt_creation():
-    robots_json = json.loads(Path("test_files/robots.json").read_text())
+    robots_json = json.loads(Path("test_files/robots.json").read_text(encoding="utf-8"))
     robots_txt = json_to_txt(robots_json)
-    assert Path("test_files/robots.txt").read_text() == robots_txt
+    assert Path("test_files/robots.txt").read_text(encoding="utf-8") == robots_txt
 
 
 def test_table_of_bot_metrices_md():
-    robots_json = json.loads(Path("test_files/robots.json").read_text())
+    robots_json = json.loads(Path("test_files/robots.json").read_text(encoding="utf-8"))
     robots_table = json_to_table(robots_json)
-    assert Path("test_files/table-of-bot-metrics.md").read_text() == robots_table
+    assert Path("test_files/table-of-bot-metrics.md").read_text(encoding="utf-8") == robots_table

--- a/code/tests.py
+++ b/code/tests.py
@@ -10,12 +10,12 @@ from dark_visitors import json_to_txt, json_to_table
 
 
 def test_robots_txt_creation():
-    robots_json = json.loads(Path("test_files/robots.json").read_text(encoding="utf-8"))
+    robots_json = json.loads(Path("test_files/robots.json").read_text())
     robots_txt = json_to_txt(robots_json)
-    assert Path("test_files/robots.txt").read_text(encoding="utf-8") == robots_txt
+    assert Path("test_files/robots.txt").read_text() == robots_txt
 
 
 def test_table_of_bot_metrices_md():
-    robots_json = json.loads(Path("test_files/robots.json").read_text(encoding="utf-8"))
+    robots_json = json.loads(Path("test_files/robots.json").read_text())
     robots_table = json_to_table(robots_json)
-    assert Path("test_files/table-of-bot-metrics.md").read_text(encoding="utf-8") == robots_table
+    assert Path("test_files/table-of-bot-metrics.md").read_text() == robots_table


### PR DESCRIPTION
My last PR #51 changed the attribution in some cases. Hence I reverted the merge of the GH Action files which restores the original attribution logic.

The work is still done with the Python. This PR does not revert to PHP.

In line with the current behaviour and contrary to pre PR #51 the main GH Action is triggered by every push to main.

--

A bit off topic is the addition of the file encoding to the tests. I believe this makes sense.

--

Update the PR link.