### PR TITLE
Allow Action to succeed even if no changes were made

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,6 +32,13 @@ jobs:
           echo "... done."
           git --no-pager diff
           git add -A
+          if [ "$(git diff --staged)" ]; then
+            # To have the action run successfully, if no changes are staged, we
+            # manually skip the later commits because they fail with exit code 1
+            # and this would then display as a failure for the Action.
+            echo "No staged changes to commit. Skipping commit and push."
+            exit 0
+          fi
           if [ -n "${{ inputs.message }}" ]; then
             git commit -m "${{ inputs.message }}"
           else

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
           echo "... done."
           git --no-pager diff
           git add -A
-          if [ "$(git diff --staged)" ]; then
+          if [ -z "$(git diff --staged)" ]; then
             # To have the action run successfully, if no changes are staged, we
             # manually skip the later commits because they fail with exit code 1
             # and this would then display as a failure for the Action.


### PR DESCRIPTION
Before, the Action would fail in case there were no changes made to any files by the converter.

I think this behaviour is the result of the action running in more scenarios than when it was initially created.

An example of a failed Action run which should have succeeded in my understanding is this: https://github.com/ai-robots-txt/ai.robots.txt/actions/runs/12624527774/job/35174915693