### PR TITLE
Block SemrushBot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -258,6 +258,13 @@
         "operator": "[Zyte](https://www.zyte.com)",
         "respect": "Unclear at this time."
     },
+    "SemrushBot": {
+        "operator": "[Semrush](https://www.semrush.com/)",
+        "respect": "[Yes](https://www.semrush.com/bot/)",
+        "function": "Scrapes data for use in LLM article-writing tool.",
+        "frequency": "Roughly once every 10 seconds.",
+        "description": "SemrushBot is a bot which, among other functions, scrapes data for use in ContentShake AI tool reports."
+    },
     "Sidetrade indexer bot": {
         "description": "AI product training.",
         "frequency": "No information.",


### PR DESCRIPTION
Information on the bot can be found here: https://www.semrush.com/bot/

Despite the robots.txt/user agent section, my webserver logs indicate that it only uses the `SemrushBot/7~bl` user agent, which isn't included in their list at all. (they say that the user agent would be suffixed with `-OCOB` for their AI tool, or some other suffix for their other tools' scrapers) As such, I chose to use the more general `SemrushBot` name.

I chose a ~10s frequency based on my own logs and on their indicated willingness to respect crawl-delay directives:

> [...] Our crawler can take intervals of up to 10 seconds between requests to a site. Higher values will be cut down to this 10-second limit. If no crawl-delay is specified, SemrushBot will adjust the frequency of requests to your site according to the current server load. 