### PR TITLE
Actually block Semrush’s AI tools

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -265,12 +265,19 @@
         "operator": "[Zyte](https://www.zyte.com)",
         "respect": "Unclear at this time."
     },
-    "SemrushBot": {
+    "SemrushBot-OCOB": {
         "operator": "[Semrush](https://www.semrush.com/)",
         "respect": "[Yes](https://www.semrush.com/bot/)",
-        "function": "Scrapes data for use in LLM article-writing tool.",
+        "function": "Crawls your site for ContentShake AI tool.",
         "frequency": "Roughly once every 10 seconds.",
-        "description": "SemrushBot is a bot which, among other functions, scrapes data for use in ContentShake AI tool reports."
+        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
+    },
+    "SemrushBot-SWA": {
+        "operator": "[Semrush](https://www.semrush.com/)",
+        "respect": "[Yes](https://www.semrush.com/bot/)",
+        "function": "Checks URLs on your site for SWA tool.",
+        "frequency": "Roughly once every 10 seconds.",
+        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
     },
     "Sidetrade indexer bot": {
         "description": "AI product training.",


### PR DESCRIPTION
Semrush has confirmed via email that the AI tools will crawl under the UA strings `SemrushBot-OCOB` and `SemrushBot-SWA`. And `SemrushBot/7~bl` is used for Backlink Analytics:

> They are not related to any AI, they just read the HTML looking for backlinks.