### PR TITLE
chore(robots.json): adds imgproxy crawler

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -195,6 +195,13 @@
         "operator": "[img2dataset](https://github.com/rom1504/img2dataset)",
         "respect": "Unclear at this time."
     },
+    "imgproxy": {
+        "frequency": "No information.",
+        "function": "Not documented or explained on operator's site.",
+        "operator": "[imgproxy](https://imgproxy.net)",
+        "respect": "Unclear at this time.",
+        "description": "AI-powered image processing."
+    },
     "ISSCyberRiskCrawler": {
         "description": "Used to train machine learning based models to quantify cyber risk.",
         "frequency": "No information.",


### PR DESCRIPTION
This adds the `imgproxy` crawler associated with [imgproxy](https://imgproxy.net).

> "World’s fastest AI-powered self-hosted image processing server."

Whether it respects `robots.txt` is unclear as the crawler is not documented on the linked site. Given that and its association with/usage of AI I'd like to include it in the file and support blocking it via `.htaccess` and any other methods we include going forward.

Thanks to Brian at Skewray Research for highlighting this one.