### PR TITLE
Include "AI Agents" from Dark Visitors

### DIFF
--- a/code/robots.py
+++ b/code/robots.py
@@ -30,6 +30,7 @@ def updated_robots_json(soup):
     """Update AI scraper information with data from darkvisitors."""
     existing_content = load_robots_json()
     to_include = [
+        "AI Agents",
         "AI Assistants",
         "AI Data Scrapers",
         "AI Search Crawlers",


### PR DESCRIPTION
Dark Visitors have added a new category for "AI Agents", seperate from "AI Assistants". They are functionally similar and we already block the latter, so the former should probably be included as well.

https://darkvisitors.com/agents