### PR TITLE
Fixed meta-external* being titlecase, and removed period for consistency

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -244,14 +244,14 @@
         "frequency": "Unclear at this time.",
         "description": "Kangaroo Bot is used by the company Kangaroo LLM to download data to train AI models tailored to Australian language and culture. More info can be found at https://darkvisitors.com/agents/agents/kangaroo-bot"
     },
-    "Meta-ExternalAgent": {
+    "meta-externalagent": {
         "operator": "[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers)",
-        "respect": "Yes.",
+        "respect": "Yes",
         "function": "Used to train models and improve products.",
         "frequency": "No information.",
         "description": "\"The Meta-ExternalAgent crawler crawls the web for use cases such as training AI models or improving products by indexing content directly.\""
     },
-    "Meta-ExternalFetcher": {
+    "meta-externalfetcher": {
         "operator": "Unclear at this time.",
         "respect": "Unclear at this time.",
         "function": "AI Assistants",


### PR DESCRIPTION
My logger indicated multiple robots.txt violations from `meta-externalagent`. Looking into their site, it seemed like they intended for it to respect it, but the user agent Meta shows in the sample robots.txt shows a lowercase user agent, as well as their actual user agent being lowercase. I suspect that their crawler is case sensitive when looking at robots.txt.

Also, there was a period after "Yes" which is inconsistent with the rest of the robots.json file.