### PR TITLE
lint robots.json during pull requests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,3 +19,10 @@ jobs:
       - name: Run tests
         run: |
           code/tests.py
+  lint-json:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: JQ Json Lint
+        run: jq . robots.json


### PR DESCRIPTION
As seen in #123 , it is possible for invalid JSON to be pushed to robots.json, which can cause exceptions elsewhere in the project or in downstream projects.

The existing python tests do not reference the robots.json in the root of the project, but rather a different one at `code/test_files/robots.json`, since they appear to be testing the generation code rather than the source data

This PR adds a simple JSON lint job using JQ to run in parallel with the python tests. This provides feedback on PRs if the JSON is valid or not, and will provide details of what is malformatted in the job log.

A failed run example can be found here: https://github.com/holysoles/ai.robots.txt/actions/runs/15049903349/job/42301866816