### PR TITLE
fix(robots.json): remove duplicate entry for Meta-ExternalAgent

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -244,17 +244,10 @@
         "frequency": "Unclear at this time.",
         "description": "Kangaroo Bot is used by the company Kangaroo LLM to download data to train AI models tailored to Australian language and culture. More info can be found at https://darkvisitors.com/agents/agents/kangaroo-bot"
     },
-    "meta-externalagent": {
+    "Meta-ExternalAgent": {
         "operator": "[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers)",
         "respect": "Yes",
         "function": "Used to train models and improve products.",
-        "frequency": "No information.",
-        "description": "\"The Meta-ExternalAgent crawler crawls the web for use cases such as training AI models or improving products by indexing content directly.\""
-    },
-    "Meta-ExternalAgent": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
-        "function": "AI Data Scrapers",
         "frequency": "Unclear at this time.",
         "description": "Meta-ExternalAgent is a web crawler used by Meta to download training data for its AI models and improve its products by indexing content directly. More info can be found at https://darkvisitors.com/agents/agents/meta-externalagent"
     },

--- a/robots.json
+++ b/robots.json
@@ -251,13 +251,6 @@
         "frequency": "Unclear at this time.",
         "description": "Meta-ExternalAgent is a web crawler used by Meta to download training data for its AI models and improve its products by indexing content directly. More info can be found at https://darkvisitors.com/agents/agents/meta-externalagent"
     },
-    "meta-externalfetcher": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
-        "function": "AI Assistants",
-        "frequency": "Unclear at this time.",
-        "description": "Meta-ExternalFetcher is dispatched by Meta AI products in response to user prompts, when they need to fetch an individual links. More info can be found at https://darkvisitors.com/agents/agents/meta-externalfetcher"
-    },
     "Meta-ExternalFetcher": {
         "operator": "Unclear at this time.",
         "respect": "Unclear at this time.",


### PR DESCRIPTION
This removes a duplicate entry for `Meta-ExternalAgent` that appears to have occurred due to the removed entry differing in casing from the retained entry. I've selected the most informative fields from the two to combine.