### PR TITLE
chore(robots.json): adds wpbot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -412,6 +412,13 @@
         "frequency": "Unclear at this time.",
         "description": "Webzio-Extended is a web crawler used by Webz.io to maintain a repository of web crawl data that it sells to other companies, including those using it to train AI models. More info can be found at https://darkvisitors.com/agents/agents/webzio-extended"
     },
+    "wpbot": {
+        "operator": "[QuantumCloud](https://www.quantumcloud.com)",
+        "respect": "Unclear at this time; opt out provided via [Google Form](https://forms.gle/ajBaxygz9jSR8p8G9)",
+        "function": "Live chat support and lead generation.",
+        "frequency": "Unclear at this time.",
+        "description": "wpbot is a used to support the functionality of the AI Chatbot for WordPress plugin. It supports the use of customer models, data collection and customer support."
+    },
     "YouBot": {
         "operator": "[You](https://about.you.com/youchat/)",
         "respect": "[Yes](https://about.you.com/youbot/)",


### PR DESCRIPTION
Adds support for `wpbot`. Pertinent portion of the updated JSON:

```json
"wpbot": {
  "operator": "[QuantumCloud](https://www.quantumcloud.com)",
  "respect": "Unclear at this time; opt out provided via [Google Form](https://forms.gle/ajBaxygz9jSR8p8G9)",
  "function": "Live chat support and lead generation.",
  "frequency": "Unclear at this time.",
  "description": "wpbot is a used to support the functionality of the AI Chatbot for WordPress plugin. It supports the use of customer models, data collection and customer support."
},
```

Reported by Brian Sutin at Skewray Research: ` [12/May/2025:08:15:46 +0000] "GET / HTTP/2" 401 52 "-" "Mozilla/5.0 (compatible; wpbot/1.3; +https://forms.gle/ajBaxygz9jSR8p8G9)"
   https://wordpress.org/plugins/chatbot/`