### PR TITLE
chore(robots.json): adds MyCentralAIScraperBot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -319,7 +319,7 @@
       "respect": "Unclear at this time.",
       "function": "AI data scraper",
       "frequency": "Unclear at this time.",
-      "description": "Operator and data use is uncleaar at this time."
+      "description": "Operator and data use is unclear at this time."
     },
     "NovaAct": {
         "operator": "Unclear at this time.",


### PR DESCRIPTION
Adds `MyCentralAIScraperBot`. I haven't been able to find much information on or details about this one. [The New York Times](https://www.nytimes.com/robots.txt) includes it in their list of blocked agents.