### PR TITLE
Update funtion and description for SemrushBot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -454,47 +454,19 @@
         "operator": "[Zyte](https://www.zyte.com)",
         "respect": "Unclear at this time."
     },
-    "SemrushBot": {
-        "operator": "[Semrush](https://www.semrush.com/)",
-        "respect": "[Yes](https://www.semrush.com/bot/)",
-        "function": "Crawls your site for ContentShake AI tool.",
-        "frequency": "Roughly once every 10 seconds.",
-        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
-    },
-    "SemrushBot-BA": {
-        "operator": "[Semrush](https://www.semrush.com/)",
-        "respect": "[Yes](https://www.semrush.com/bot/)",
-        "function": "Crawls your site for ContentShake AI tool.",
-        "frequency": "Roughly once every 10 seconds.",
-        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
-    },
-    "SemrushBot-CT": {
-        "operator": "[Semrush](https://www.semrush.com/)",
-        "respect": "[Yes](https://www.semrush.com/bot/)",
-        "function": "Crawls your site for ContentShake AI tool.",
-        "frequency": "Roughly once every 10 seconds.",
-        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
-    },
     "SemrushBot-OCOB": {
         "operator": "[Semrush](https://www.semrush.com/)",
         "respect": "[Yes](https://www.semrush.com/bot/)",
         "function": "Crawls your site for ContentShake AI tool.",
         "frequency": "Roughly once every 10 seconds.",
-        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
-    },
-    "SemrushBot-SI": {
-        "operator": "[Semrush](https://www.semrush.com/)",
-        "respect": "[Yes](https://www.semrush.com/bot/)",
-        "function": "Crawls your site for ContentShake AI tool.",
-        "frequency": "Roughly once every 10 seconds.",
-        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
+        "description": "Data collected is used for the ContentShake AI tool reports."
     },
     "SemrushBot-SWA": {
         "operator": "[Semrush](https://www.semrush.com/)",
         "respect": "[Yes](https://www.semrush.com/bot/)",
-        "function": "Checks URLs on your site for SWA tool.",
+        "function": "Checks URLs on your site for SEO Writing Assistant.",
         "frequency": "Roughly once every 10 seconds.",
-        "description": "You enter one text (on-demand) and we will make suggestions on it (the tool uses AI but we are not actively crawling the web, you need to manually enter one text/URL)."
+        "description": "Data collected is used for the SEO Writing Assistant tool to check if URL is accessible."
     },
     "Sidetrade indexer bot": {
         "description": "AI product training.",


### PR DESCRIPTION
@glyn mentioned https://github.com/ai-robots-txt/ai.robots.txt/pull/73#issuecomment-2618570717 and asked why Semrush stated that SemrushBot-SWA is for AI. So I looked it up and SWA stands for SEO Writing Assistant: https://www.semrush.com/swa/. Like similar writing assistants, it’s using AI to make suggestions. (In a previous iteration, it was actually called [AI Writing Assistant](https://www.semrush.com/apps/ai-writing-assistant/).)

This PR updates function and description for the two known AI bots from Semrush.

If there’s any lingering concerns about the other UA strings, please air them below and let’s confront the company directly.

https://www.semrush.com/bot/