### PR TITLE
chore(robots.json): add SummalyBot + Thinkbot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -524,12 +524,26 @@
         "operator": "[Sidetrade](https://www.sidetrade.com)",
         "respect": "Unclear at this time."
     },
+    "SummalyBot": {
+        "description": "AI input summarization.",
+        "frequency": "No information.",
+        "function": "Extracts data to provide summaries for user; additional usages unclear.",
+        "operator": "[Grammarly](https://www.grammarly.com/ai/ai-writing-tools/summarizing-tool) (suspected not definitively known at this time)",
+        "respect": "Unclear at this time."
+    },
     "TikTokSpider": {
         "operator": "ByteDance",
         "respect": "Unclear at this time.",
         "function": "LLM training.",
         "frequency": "Unclear at this time.",
         "description": "Downloads data to train LLMS, as per Bytespider."
+    },
+    "Thinkbot": {
+        "operator": "[Thinkbot](https://www.thinkbot.agency)",
+        "respect": "No",
+        "function": "Insights on AI integration and automation.",
+        "frequency": "Unclear at this time.",
+        "description": "Collects data for analysis on AI usage and automation."
     },
     "Timpibot": {
         "operator": "[Timpi](https://timpi.io)",


### PR DESCRIPTION
Adds `SummalyBot` and `Thinkbot` reported by Brian at [Skewray Research](https://skewray.com).

```
(compatible; Thinkbot/0.5.8; +In_the_test_phase,_if_the_Thinkbot_brings_you_trouble,_please_block_its_IP_address._Thank_you.)"
```

`HTTP/1.1" 200 0 "SummalyBot/5.2.0`