### PR TITLE
Adding YaK 

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -590,7 +590,7 @@
 	"YaK": {
 		"operator": "[Meltwater](https://www.meltwater.com/en/suite/consumer-intelligence)",
 		"respect": "Unclear at this time.",
-		"function": "According to the [Meltwater Consumer Intelligence page](https://www.meltwater.com/en/suite/consumer-intelligence) 'By applying AI, data science, and market research expertise to a live feed of global data sources, we transform unstructured data into actionable insights allowing better decision-making'."
+		"function": "According to the [Meltwater Consumer Intelligence page](https://www.meltwater.com/en/suite/consumer-intelligence) 'By applying AI, data science, and market research expertise to a live feed of global data sources, we transform unstructured data into actionable insights allowing better decision-making'.",
 		"frequency": "Unclear at this time.",
 		"description": "Retrieves data used for Meltwater's AI enabled consumer intelligence suite"
 	},


### PR DESCRIPTION
Added [Meltwater's AI](http://linkfluence.com/) to list of bots.

The full user-agent I saw in my website was `Mozilla/5.0 (compatible; YaK/1.0; http://linkfluence.com/; bot@linkfluence.com)`.