### PR TITLE
Update Brightbot operator and details; add meta-webindexer entry

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -84,11 +84,11 @@
         "description": "bigsur.ai is a web crawler operated by Big Sur AI that fetches website content to enable AI-powered web agents, sales assistants, and content marketing solutions for businesses. More info can be found at https://darkvisitors.com/agents/agents/bigsur-ai"
     },
     "Brightbot 1.0": {
-        "operator": "Browsing.ai",
+        "operator": "https://brightdata.com/brightbot",
         "respect": "Unclear at this time.",
         "function": "LLM/AI training.",
-        "frequency": "Unclear at this time.",
-        "description": "Scrapes data to train LLMs and AI products focused on website customer support."
+        "frequency": "At least one per minute.",
+        "description": "Scrapes data to train LLMs and AI products focused on website customer support, [uses residential IPs and legit-looking user-agents to disguise itself](https://ksol.io/en/blog/posts/brightbot-not-that-bright/)."
     },
     "Bytespider": {
         "operator": "ByteDance",
@@ -390,6 +390,13 @@
         "function": "AI Assistants",
         "frequency": "Unclear at this time.",
         "description": "Meta-ExternalFetcher is dispatched by Meta AI products in response to user prompts, when they need to fetch an individual links. More info can be found at https://darkvisitors.com/agents/agents/meta-externalfetcher"
+    },
+    "meta-webindexer": {
+        "operator": "[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
+        "respect": "Unclear at this time.",
+        "function": "AI Assistants",
+        "frequency": "Unhinged, more than 1 per second.",
+        "description": "As per their documentation, \"The Meta-WebIndexer crawler navigates the web to improve Meta AI search result quality for users. In doing so, Meta analyzes online content to enhance the relevance and accuracy of Meta AI. Allowing Meta-WebIndexer in your robots.txt file helps us cite and link to your content in Meta AI's responses.\""
     },
     "Meta-ExternalFetcher": {
         "operator": "Unclear at this time.",


### PR DESCRIPTION
- Update Brightbot operator to https://brightdata.com/brightbot.
- Change Brightbot frequency to "At least one per minute."
- Expand Brightbot description with disguise tactics link.
- Add new entry for meta-webindexer under Meta operator.
- Set meta-webindexer respect to "Unclear at this time."
- Define meta-webindexer function as "AI Assistants."
- Set meta-webindexer frequency to "Unhinged, more than 1 per second."
- Include meta-webindexer description on improving Meta AI search.