### PR TITLE
Add NagetBot and newsai user-agents

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -664,12 +664,26 @@
         "frequency": "Unclear at this time.",
         "description": "Operator and data use is unclear at this time."
     },
+    "NagetBot": {
+        "operator": "Naget Inc (founded by Chris Samarinas, headquarter in Amherst, Massachusetts)",
+        "respect": "Unclear at this time.",
+        "function": "AI data scraper",
+        "frequency": "Unclear at this time.",
+        "description": "'Naget revolutionizes content discovery through an AI-powered ecosystem that transforms how we generate, organize, share, and discover valuable content.' (https://naget.com/) User-agent string links https://naget.ai/bot which yields 404."
+    },
     "netEstate Imprint Crawler": {
         "operator": "netEstate",
         "respect": "Unclear at this time.",
         "function": "AI Data Scrapers",
         "frequency": "Unclear at this time.",
         "description": "netEstate Imprint Crawler is an AI data scraper operated by netEstate. If you think this is incorrect or can provide additional detail about its purpose, please contact us. More info can be found at https://darkvisitors.com/agents/agents/netestate-imprint-crawler"
+    },
+    "newsai": {
+        "operator": "Unclear at this time.",
+        "respect": "Unclear at this time.",
+        "function": "AI data scraper",
+        "frequency": "Unclear at this time.",
+        "description": "User-agent string doen't contain an URL and there multiple sites using the newsai brand."
     },
     "NotebookLM": {
         "operator": "Unclear at this time.",


### PR DESCRIPTION
User-agent header values seen in the wild over the last days:

    Mozilla/5.0 (compatible; NagetBot/1.0; +https://naget.ai/bot)
    Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 newsai/1.0 Safari/537.36