### PR TITLE
add: AgentTimes bot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -34,6 +34,13 @@
         "frequency": "No information provided.",
         "description": "Scrapes data for AI systems."
     },
+    "AgentTimes": {
+        "operator": "[The Agent Times](https://theagenttimes.com/about)",
+        "respect": "Unclear at this time.",
+        "function": "Data Scraper from RSS Feeds.",
+        "frequency": "Requests RSS feed every 5-6 minutes.",
+        "description": "Scrapes data for AI news aggregation and republishing."
+    },
     "amazon-kendra": {
         "operator": "Amazon",
         "respect": "Yes",


### PR DESCRIPTION
This bot has recently begin scrapping my RSS feed every 5-6 minutes as part of an Agent-to-Agent "news" generation; it does not appear to listen to robots.txt.

<img width="1052" height="789" alt="image" src="https://github.com/user-attachments/assets/bed1a151-a618-4434-8a4b-bc304f66281a" />
