### PR TITLE
Fill "Unclear at this time." from primary operator docs for 6 entries

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -126,8 +126,8 @@
         "description": "ApifyWebsiteContentCrawler is a web crawler by Apify that extracts and downloads full website content for use in AI, data analysis, and automation workflows. More info can be found at https://knownagents.com/agents/apifywebsitecontentcrawler"
     },
     "Applebot": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
+        "operator": "[Apple](https://support.apple.com/en-us/119829)",
+        "respect": "[Yes](https://support.apple.com/en-us/119829)",
         "function": "AI Search Crawlers",
         "frequency": "Unclear at this time.",
         "description": "Applebot is a web crawler used by Apple to index search results that allow the Siri AI Assistant to answer user questions. Siri's answers normally contain references to the website. More info can be found at https://knownagents.com/agents/applebot"
@@ -386,8 +386,8 @@
         "description": "Diffbot is a web crawler that extracts and structures website content using AI-powered visual understanding, providing knowledge graph data for applications like market i\u2026 More info can be found at https://knownagents.com/agents/diffbot"
     },
     "DuckAssistBot": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
+        "operator": "[DuckDuckGo](https://duckduckgo.com/duckduckgo-help-pages/results/duckassistbot/)",
+        "respect": "[Yes](https://duckduckgo.com/duckduckgo-help-pages/results/duckassistbot/)",
         "function": "AI Assistants",
         "frequency": "Unclear at this time.",
         "description": "DuckAssistBot is a web crawler that scans websites to collect content for DuckDuckGo's AI-assisted answers feature, which generates brief responses to search queries usin\u2026 More info can be found at https://knownagents.com/agents/duckassistbot"
@@ -463,8 +463,8 @@
         "description": "Gemini-Deep-Research is the agent responsible for collecting and scanning resources used in Google Gemini's Deep Research feature, which acts as a personal research assis\u2026 More info can be found at https://knownagents.com/agents/gemini-deep-research"
     },
     "Google-Agent": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
+        "operator": "[Google](https://developers.google.com/crawling/docs/crawlers-fetchers/google-user-triggered-fetchers)",
+        "respect": "[No](https://developers.google.com/crawling/docs/crawlers-fetchers/google-user-triggered-fetchers)",
         "function": "AI Agents",
         "frequency": "Unclear at this time.",
         "description": "Google-Agent is used by agents hosted on Google infrastructure to navigate the web and perform actions upon user request. More info can be found at https://knownagents.com/agents/google-agent"
@@ -708,22 +708,22 @@
         "description": "\"The Meta-ExternalAgent crawler crawls the web for use cases such as training AI models or improving products by indexing content directly.\""
     },
     "Meta-ExternalAgent": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
+        "operator": "[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
+        "respect": "[Yes](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
         "function": "AI Data Scrapers",
         "frequency": "Unclear at this time.",
         "description": "Meta-ExternalAgent is a web crawler used by Meta to download training data for its AI models and improve its products by indexing content directly. More info can be found at https://knownagents.com/agents/meta-externalagent"
     },
     "meta-externalfetcher": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
+        "operator": "[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
+        "respect": "[No](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
         "function": "AI Assistants",
         "frequency": "Unclear at this time.",
         "description": "meta-externalfetcher is used by Meta to perform user-initiated fetches of individual links from AI assistant product functions. More info can be found at https://knownagents.com/agents/meta-externalfetcher"
     },
     "Meta-ExternalFetcher": {
-        "operator": "Unclear at this time.",
-        "respect": "Unclear at this time.",
+        "operator": "[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
+        "respect": "[No](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/)",
         "function": "AI Assistants",
         "frequency": "Unclear at this time.",
         "description": "Meta-ExternalFetcher is dispatched by Meta AI products in response to user prompts, when they need to fetch an individual links. More info can be found at https://knownagents.com/agents/meta-externalfetcher"


### PR DESCRIPTION
Six entries carry `"Unclear at this time."` for both `operator` and `respect`, but the operator does document the behaviour on its own site. This fills those in and links the primary source inline, matching the style already used in this file — `Applebot-Extended` already links `[Apple](https://support.apple.com/en-us/119829#datausage)`, and `meta-externalagent` already links `[Meta](https://developers.facebook.com/docs/sharing/webmasters/web-crawlers)`.

Only `robots.json` is touched; the generated files are left to the Action. **`robots.txt` output is unchanged** — no keys were added or renamed, so this only affects `table-of-bot-metrics.md`.

I checked twelve `Unclear` entries in total and am only proposing the ones where an operator statement actually exists. The seven I am **not** touching are listed at the bottom with the reason — there, `Unclear at this time.` is the correct value and should stay.

### Changes

| Crawler | respect | The operator's own words |
|---|---|---|
| `Applebot` | → `[Yes]` | "Applebot respects standard robots.txt directives in general search crawls that are targeted at Applebot." |
| `Meta-ExternalAgent` | → `[Yes]` | "In order to block these crawlers, add a disallow for the relevant crawler to robots.txt." — the exceptions are then named explicitly, and this agent is not one of them |
| `Meta-ExternalFetcher` | → `[No]` | "The Meta-ExternalFetcher crawler may bypass robots.txt because it performs fetches that were requested by the user." |
| `meta-externalfetcher` | → `[No]` | same source — see the note on duplicates below |
| `DuckAssistBot` | → `[Yes]` | "Once you've updated the file to disallow the DuckAssistBot user agent, the change will take effect after 72 hours and DuckAssistBot will stop crawling your site." |
| `Google-Agent` | → `[No]` | "Because the fetch was requested by a user, these fetchers generally ignore robots.txt rules." |

`operator` is filled from the same primary page in each case.

Sources:

- Apple — https://support.apple.com/en-us/119829 (page dated 2026-06-08)
- Meta — https://developers.facebook.com/docs/sharing/webmasters/web-crawlers/
- DuckDuckGo — https://duckduckgo.com/duckduckgo-help-pages/results/duckassistbot/
- Google — https://developers.google.com/crawling/docs/crawlers-fetchers/google-user-triggered-fetchers

### Three judgement calls, flagged rather than buried

I would rather you push back on these than have them slip through:

1. **`Meta-ExternalAgent` = Yes** rests on scope, not a single sentence. Meta's robots.txt section addresses "these crawlers" collectively, then names its exceptions — `Meta-ExternalFetcher` and `FacebookExternalHit`. `Meta-ExternalAgent` is not among them, and it is the agent used in that page's only worked robots.txt example. Supporting signal: the existing `meta-externalagent` entry in this file is already `Yes` on the same basis. If you apply a stricter "one sentence naming this exact UA" bar, this should stay `Unclear`.

2. **`Google-Agent` = No** comes from a class-level sentence about user-triggered fetchers, on the page that enumerates `Google-Agent` as one of them. Note the hedge: Google writes fetchers "**generally** ignore robots.txt rules", not "always". I read that as No; you may prefer something softer.

3. **`Meta-ExternalFetcher` = No** — Meta says the crawler "**may** bypass robots.txt". I read this as No rather than conditional because the same page defines this agent as one that only fetches at a user's request, so the bypass clause covers all of its traffic.

For `Applebot`, two caveats that do not change the verdict but are worth knowing: Apple states "Applebot does not follow crawl-delay", and that if robots.txt does not mention Applebot but does mention Googlebot, Applebot follows the Googlebot rules.

### Noticed while doing this: three case-duplicate entries

Not fixed here, since deduplication would change generated output and is your call:

- `meta-externalagent` / `Meta-ExternalAgent`
- `meta-externalfetcher` / `Meta-ExternalFetcher`
- `webzio-extended` / `Webzio-Extended`

Per RFC 9309 the product token is matched case-insensitively, so each pair is one crawler. I patched both halves of the `meta-externalfetcher` pair so they do not disagree with each other after this PR; the other two pairs are already consistent. Happy to open a separate PR to merge them if you want that cleaned up.

### Checked and deliberately left as `Unclear at this time.`

| Crawler | Why it stays Unclear |
|---|---|
| `anthropic-ai` | Anthropic's current crawler article names only ClaudeBot, Claude-User and Claude-SearchBot. The string `anthropic-ai` does not appear on that page at all — it looks like a retired token, so the compliance statement covering the other three cannot be stretched to it. |
| `MistralAI-User` | Mistral's crawler docs describe what the token scopes but never state that directives are honoured. |
| `cohere-training-data-crawler` | No first-party Cohere page names this user-agent. |
| `cohere-ai` | Same — no first-party documentation found. |
| `Diffbot` | Diffbot documents robots.txt adherence as a default that can be overridden by agreement and toggled per customer. The existing "At the discretion of Diffbot users." arguably captures that better than a Yes/No. |
| `kagi-fetcher` | No explicit statement for this exact agent name. |
| `meta-webindexer` | Not covered by an explicit statement naming this token. |

### Not in this PR

Three agents are absent from `robots.json` entirely and would be additions rather than corrections: `meta-externalads`, `OAI-AdsBot` (OpenAI documents the agent and publishes an IP file, but says nothing about robots.txt) and `Diffbot-User`. Happy to open a separate PR if additions are welcome — keeping this one to corrections only.

### How this was checked

Operator documentation only; third-party crawler directories were excluded as sources, including the knownagents.com links currently in these entries' `description` fields. Where a page blocked automated fetching, the text was confirmed against a Wayback snapshot of the same URL and re-checked live. Descriptions were left untouched. `code/tests.py` passes (13/13).

Cross-checked while maintaining a separate AI-crawler reference dataset at https://agentswelcome.dev/crawlers — happy to share the per-field source URLs behind any of the above if that helps review.
