### PR TITLE
Pass commit messages to bash via env, not template interpolation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 2
-      - run: |
+      - env:
+          INPUT_MESSAGE: ${{ inputs.message }}
+          HEAD_COMMIT_MESSAGE: ${{ github.event.head_commit.message }}
+        run: |
           pip install beautifulsoup4
           git config --global user.name "ai.robots.txt"
           git config --global user.email "ai.robots.txt@users.noreply.github.com"
@@ -39,10 +42,10 @@ jobs:
             echo "No staged changes to commit. Skipping commit and push."
             exit 0
           fi
-          if [ -n "${{ inputs.message }}" ]; then
-            git commit -m "${{ inputs.message }}"
+          if [ -n "$INPUT_MESSAGE" ]; then
+            git commit -m "$INPUT_MESSAGE"
           else
-            git commit -m "${{ github.event.head_commit.message }}"
+            git commit -m "$HEAD_COMMIT_MESSAGE"
           fi
           git push
         shell: bash


### PR DESCRIPTION
Follow-up to #248, as requested there.

## What broke

`main.yml` interpolates the commit message directly into a double-quoted bash string:

```yaml
git commit -m "${{ github.event.head_commit.message }}"
```

A message containing a double quote closes that string early, and bash re-parses the remainder as shell words.

That is what happened when #248 merged. Its title contained `"Unclear at this time."` with quotes, so the merge commit message did too, and the line bash actually ran was:

```
git commit -m "Fill "Unclear at this time." from primary operator docs for 6 entries (#248)"
```

which git received as:

```
-m "Fill Unclear"   at   this   "time. from primary operator docs for 6 entries (#248)"
```

Reproduced locally — git reports exactly what the failed run showed:

```
error: pathspec 'at' did not match any file(s) known to git
error: pathspec 'this' did not match any file(s) known to git
error: pathspec 'time. from primary operator docs for 6 entries (#248)' did not match any file(s) known to git
```

The data in #248 was not the cause: at its head, `python code/robots.py --convert` exits 0 and `code/tests.py` passes 13/13.

## Why this matters beyond the one broken run

A PR title is attacker-controlled, so the same line is a script-injection vector. A title of the form

```
chore: tidy"; <any command>; echo "
```

runs that command on the runner with the workflow's token. I verified this locally with a harmless payload (`id -un`, which printed). The env form treats the identical input as literal text.

## The change

Move `github.event.head_commit.message` and `inputs.message` into `env:` and reference them as quoted shell variables. `inputs.message` appears three times — the `if [ -n ... ]` test and both `git commit -m` calls — so all are covered. This is [GitHub's documented recommendation](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) for untrusted values: the variable is expanded by bash *after* parsing, so quotes, newlines and `$(...)` stay literal.

Behaviour is otherwise unchanged — when `inputs.message` is absent it is still the empty string, so the `else` branch still handles push events.

## Verification

- `code/tests.py` — 13/13 OK
- `python code/robots.py --convert` — exits 0, leaves `robots.txt`, `table-of-bot-metrics.md`, `.htaccess`, the nginx/lighttpd/haproxy configs and the `Caddyfile` byte-identical
- Reproduced the parse failure and the injection against the old form; confirmed the env form commits the same message verbatim, quotes included
- Only `.github/workflows/main.yml` is touched

Once this lands I will re-submit the #248 data with its original title, as you asked.