### PR TITLE
robots.py: list_to_pcre gets support for sends_full_name

### DIFF
--- a/code/robots.py
+++ b/code/robots.py
@@ -191,15 +191,16 @@ def list_to_pcre(robots_json):
         for agent, config in robots_json.items()
         if config.get("sends_full_name", False)
     )
-    patterns = [f"^({exact_agents})$"]
+    patterns.extend( f"^({exact_agents})$" )
 
     # agents who use Name/1.1.3-style elements 
-    patterns.extend(
+    versioned_agents = "|".join(
         f"{re.escape(agent)}/[0-9.]+"
         for agent, config in robots_json.items()
         if config.get("has_name_and_version", False)
     )
-    
+    patterns.extend( versioned_agents )
+        
     return f"({'|'.join(patterns)})"
 
 

--- a/code/robots.py
+++ b/code/robots.py
@@ -178,27 +178,27 @@ def list_to_pcre(robots_json):
     patterns = []
 
     # regular old substring matches:
-    formatted = "|".join(
+    formatted = "|".join([
         f"{re.escape(agent)}"
         for agent, config in robots_json.items()
         if not config.get("sends_full_name", False) and not config.get("has_name_and_version", False)
-    )
+    ])
     patterns.extend( f"({formatted})" )
 
     # agents that just send their names pokemon-style
-    exact_agents = "|".join(
+    exact_agents = "|".join([
         f"^{re.escape(agent)}$"
         for agent, config in robots_json.items()
         if config.get("sends_full_name", False)
-    )
+    ])
     patterns.extend( f"^({exact_agents})$" )
 
     # agents who use Name/1.1.3-style elements 
-    versioned_agents = "|".join(
+    versioned_agents = "|".join([
         f"{re.escape(agent)}/[0-9.]+"
         for agent, config in robots_json.items()
         if config.get("has_name_and_version", False)
-    )
+    ])
     patterns.extend( versioned_agents )
         
     return f"({'|'.join(patterns)})"

--- a/code/robots.py
+++ b/code/robots.py
@@ -178,23 +178,23 @@ def list_to_pcre(robots_json):
     patterns = []
 
     # regular old substring matches:
-    formatted = "|".join([
+    formatted = [
         f"{re.escape(agent)}"
         for agent, config in robots_json.items()
         if not config.get("sends_full_name", False) and not config.get("has_name_and_version", False)
-    ])
-    patterns.extend( f"({formatted})" )
+    ]
+    patterns.extend( formatted )
 
     # agents that just send their names pokemon-style
-    exact_agents = "|".join([
+    exact_agents = [
         f"^{re.escape(agent)}$"
         for agent, config in robots_json.items()
         if config.get("sends_full_name", False)
     ])
-    patterns.extend( f"^({exact_agents})$" )
+    patterns.extend(exact_agents)
 
     # agents who use Name/1.1.3-style elements 
-    versioned_agents = "|".join([
+    versioned_agents = [
         f"{re.escape(agent)}/[0-9.]+"
         for agent, config in robots_json.items()
         if config.get("has_name_and_version", False)

--- a/code/robots.py
+++ b/code/robots.py
@@ -175,13 +175,31 @@ def json_to_table(robots_json):
 def list_to_pcre(robots_json):
     # Python re is not 100% identical to PCRE which is used by Apache, but it
     # should probably be close enough in the real world for re.escape to work.
-    exact_agents = "|".join(map(re.escape, robots_json))
+    patterns = []
+
+    # regular old substring matches:
+    formatted = "|".join(
+        f"{re.escape(agent)}"
+        for agent, config in robots_json.items()
+        if not config.get("sends_full_name", False) and not config.get("has_name_and_version", False)
+    )
+    patterns.extend( f"({formatted})" )
+
+    # agents that just send their names pokemon-style
+    exact_agents = "|".join(
+        f"^{re.escape(agent)}$"
+        for agent, config in robots_json.items()
+        if config.get("sends_full_name", False)
+    )
     patterns = [f"^({exact_agents})$"]
+
+    # agents who use Name/1.1.3-style elements 
     patterns.extend(
         f"{re.escape(agent)}/[0-9.]+"
         for agent, config in robots_json.items()
         if config.get("has_name_and_version", False)
     )
+    
     return f"({'|'.join(patterns)})"
 
 

--- a/code/robots.py
+++ b/code/robots.py
@@ -190,7 +190,7 @@ def list_to_pcre(robots_json):
         f"^{re.escape(agent)}$"
         for agent, config in robots_json.items()
         if config.get("sends_full_name", False)
-    ])
+    ]
     patterns.extend(exact_agents)
 
     # agents who use Name/1.1.3-style elements 
@@ -198,7 +198,7 @@ def list_to_pcre(robots_json):
         f"{re.escape(agent)}/[0-9.]+"
         for agent, config in robots_json.items()
         if config.get("has_name_and_version", False)
-    ])
+    ]
     patterns.extend( versioned_agents )
         
     return f"({'|'.join(patterns)})"


### PR DESCRIPTION
A similar flag to `has_name_and_version`, but It's not set anywhere yet...

This should mean that the pre-existing ones on the list don't get exported as full matches

closes #257