### PR TITLE
Add Bot Ledger to Related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ middleware plugin for [Traefik](https://traefik.io/traefik/) to automatically ad
 file on-the-fly.
 
 - Alternatively you can [manually configure Traefik](./docs/traefik-manual-setup.md) to centrally serve a static `robots.txt`.
+
+- [Bot Ledger](https://farrelldan.github.io/ai-bot-directory/): free, static directory of verified AI crawlers with a one-click `robots.txt` and `llms.txt` generator. No signup required.
+
 ## Contributing
 
 A note about contributing: updates should be added/made to `robots.json`. A GitHub action will then generate the updated `robots.txt`, `table-of-bot-metrics.md`, `.htaccess` and `nginx-block-ai-bots.conf`.


### PR DESCRIPTION
Adds [Bot Ledger](https://farrelldan.github.io/ai-bot-directory/) to the Related section.

Bot Ledger is a free, static directory of verified AI crawlers (32 entries, sourced/cross-checked against public AI-crawler documentation) with a one-click `robots.txt` and `llms.txt` generator. No signup, no tracking, no backend — just a static site.

It's directly complementary to this project: same underlying goal of helping site owners understand and manage AI crawler access, but focused on the generator/lookup use case rather than the block-list use case this repo provides. Happy to adjust placement or wording if you'd prefer a different section.