### PR TITLE
Add ExaSearchBot to robots.json

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -413,6 +413,13 @@
         "frequency": "Unclear at this time.",
         "description": "ExaBot is a web crawler that indexes web content to power Exa's AI search engine and semantic search APIs for AI applications. More info can be found at https://knownagents.com/agents/exabot"
     },
+    "ExaSearchBot": {
+        "operator": "[Exa](https://exa.ai)",
+        "respect": "Unclear at this time.",
+        "function": "AI Search Crawlers",
+        "frequency": "Unclear at this time.",
+        "description": "ExaSearchBot is a web crawler operated by Exa that discovers and indexes public web pages so their content can be found, retrieved, and cited through Exa. More info can be found at https://knownagents.com/agents/exasearchbot"
+    },
     "FacebookBot": {
         "operator": "Meta/Facebook",
         "respect": "[Yes](https://developers.facebook.com/docs/sharing/bot/)",


### PR DESCRIPTION
Closes #246

`ExaBot` is already listed, but Exa's search crawler `ExaSearchBot` was missing.

Details are taken from [Known Agents](https://knownagents.com/agents/exasearchbot), which the README already credits as a source: operated by Exa, crawls to discover and index public pages so they can be surfaced and cited through Exa. Its user agent is `Mozilla/5.0 (compatible; ExaSearchBot/1.0; +https://crawler.exa.ai/)`; the report in #246 saw the same token with an older `+https://exa.ai/bot` URL.

`respect` is left as "Unclear at this time." — Known Agents lists it as *expected* to follow robots.txt, but Exa publishes no commitment I could point at, so a documented "Yes" did not seem warranted.

Only `robots.json` is touched, per the contributing note; the generated files are left for the action.
