### PR TITLE
test: pin the SLCC1/SLCC2 false positive from #208, and document whole-word matching

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -32,6 +32,21 @@ Yes, provided the crawlers identify themselves and your application/hosting supp
 
 Some crawlers — [such as Perplexity](https://rknight.me/blog/perplexity-ai-is-lying-about-its-user-agent/) — do not identify themselves via their user agent strings and, as such, are difficult to block.
 
+## Can I use `robots.json` directly in my own tooling?
+
+You're welcome to, with a caveat. `robots.json` isn't intended as a primary
+deliverable of this project — the generated configuration files are. If you consume
+it yourself, note that **the agent names are matched as whole words**, not as
+substrings.
+
+The generated configs wrap the list in `\b(...)\b` for exactly this reason. Without
+word boundaries, short agent names match inside unrelated strings: the listed agent
+`LCC` appears inside `SLCC1`, a Windows licensing component present in the user
+agent of older Internet Explorer and Trident-based browsers. A naive substring match
+would block those real visitors ([#208](https://github.com/ai-robots-txt/ai.robots.txt/issues/208)).
+
+If you build your own matcher from `robots.json`, use word-boundary matching.
+
 ## What can we do if a bot doesn't respect `robots.txt`?
 
 That depends on your stack.

--- a/FAQ.md
+++ b/FAQ.md
@@ -36,16 +36,11 @@ Some crawlers — [such as Perplexity](https://rknight.me/blog/perplexity-ai-is-
 
 You're welcome to, with a caveat. `robots.json` isn't intended as a primary
 deliverable of this project — the generated configuration files are. If you consume
-it yourself, note that **the agent names are matched as whole words**, not as
+it yourself, note that the agent names should be matched as whole words rather than
 substrings.
 
-The generated configs wrap the list in `\b(...)\b` for exactly this reason. Without
-word boundaries, short agent names match inside unrelated strings: the listed agent
-`LCC` appears inside `SLCC1`, a Windows licensing component present in the user
-agent of older Internet Explorer and Trident-based browsers. A naive substring match
-would block those real visitors ([#208](https://github.com/ai-robots-txt/ai.robots.txt/issues/208)).
-
-If you build your own matcher from `robots.json`, use word-boundary matching.
+The generated configs wrap items in `\b(...)\b` for this reason. Without
+word boundaries, agent names match inside unrelated strings (see [issue 208](https://github.com/ai-robots-txt/ai.robots.txt/issues/208) for an example).
 
 ## What can we do if a bot doesn't respect `robots.txt`?
 

--- a/code/tests.py
+++ b/code/tests.py
@@ -126,6 +126,13 @@ class TestUserAgentPatternGeneration(unittest.TestCase):
             "NotAmazonbot/1.0",
             "NotApplebot/1.0",
             "NotBytespider/1.0",
+            # Real-world user agents that embed a listed bot name mid-string.
+            # These older Internet Explorer / Trident agents contain "SLCC1" or
+            # "SLCC2" (a Windows licensing component), which spans the listed
+            # agent "LCC". Reported in #208 and fixed by the word boundaries
+            # added in #260; pinned here so the specific report cannot regress.
+            "Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.0.30729)",
+            "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; Media Center PC 6.0)",
         ]
 
         for ua in non_ai_user_agents:


### PR DESCRIPTION
Following up on #208, where @glyn said a PR for improved integration tests and/or a FAQ update would be welcome.

## Test

`test_generated_regex_does_not_match_non_ai_user_agents` already covers synthetic prefix/suffix variants — `NotCursor/1.0`, `CursorNot/1.0`, and so on. What it had no case for is a **real-world** user agent that embeds a listed name mid-string, which is what #208 actually reported: `SLCC1` and `SLCC2` (a Windows licensing component) appear in older Internet Explorer and Trident agents and span the listed agent `LCC`.

This adds both reported agents, with a comment pointing at #208 and #260 so the next reader knows they are from a real report rather than invented.

**Being straight about what this does and does not add:** the existing synthetic cases already catch the general regression — remove the word boundaries and `NotCursor/1.0` fails too. This pins the *specific* report, which closes the loop on your original ask in #208 ("ideally it would be good to reproduce the bug in a test").

I checked the case is load-bearing rather than assuming it. Removing `\b` from `list_to_pcre`:

```
AssertionError: <re.Match object; span=(65, 68), match='LCC'> is not None
```

Restored, the suite is green (14 tests, OK).

## FAQ

A short entry noting that agent names are matched as **whole words**, aimed at anyone consuming `robots.json` directly and writing their own matcher — a substring match on `LCC` still hits `SLCC1`. I have tried to reflect your framing that `robots.json` is not a primary deliverable of the project, so it reads as "you are welcome to, with a caveat" rather than as a supported interface. Happy to reword or drop it entirely if that lands wrong.

No behaviour changes; tests and docs only.