### PR TITLE
Add Reflectionbot to robots.json

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -945,6 +945,13 @@
         "operator": "[Quillbot](https://quillbot.com)",
         "respect": "Unclear at this time."
     },
+    "Reflectionbot": {
+        "operator": "[Reflection](https://reflection.ai/)",
+        "respect": "Unclear at this time.",
+        "function": "Undocumented AI Agents",
+        "frequency": "Unclear at this time.",
+        "description": "An undocumented crawler whose user agent links to Reflection, a company that builds AI models."
+    },
     "SBIntuitionsBot": {
         "operator": "[SB Intuitions](https://www.sbintuitions.co.jp/en/)",
         "respect": "[Yes](https://www.sbintuitions.co.jp/en/bot/)",


### PR DESCRIPTION
## Summary
- add `Reflectionbot` to the canonical `robots.json` list
- classify it conservatively as an undocumented AI agent
- leave respect and crawl frequency unclear because the user-agent's `/bot` URL is not documented

Only `robots.json` is changed; the generated blocker files are left to the post-merge action, per the contributing guidance.

## Testing
- `python code/tests.py` (14 tests)
- `python -m json.tool robots.json`
- `python -m compileall -q code`
- `python code/robots.py --convert` in an isolated copy (all seven generated artifacts contain `Reflectionbot`)

Closes #268
