### PR TITLE
Correct AIWebIndex metadata

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -42,11 +42,11 @@
         "description": "Scrapes data for AI systems."
     },
     "AIWebIndex": {
-        "operator": "Lyrenth that builds an AI-readable index of web content for AI systems",
-        "respect": "Unclear at this time.",
-        "function": "AI Data Providers",
-        "frequency": "Unclear at this time.",
-        "description": "AIWebIndex is a web crawler operated by Lyrenth that builds an AI-readable index of web content for AI systems. More info can be found at https://knownagents.com/agents/aiwebindex"
+        "operator": "[Lyrenth](https://lyrenth.com)",
+        "respect": "[Yes](https://lyrenth.com/crawler-policy)",
+        "function": "AI Search Crawlers",
+        "frequency": "At most one request per domain every 2 seconds, and slower where robots.txt sets a longer Crawl-delay.",
+        "description": "Builds an index of public pages and serves them to AI agents as extracted, readable text with attribution and a link back to the source. Does not train foundation models on crawled content. Identity can be checked three ways: published IP ranges at https://lyrenth.com/bot/ip-ranges.json, forward-confirmed reverse DNS under lyrenth.com, and Web Bot Auth signatures (RFC 9421). Full policy at https://lyrenth.com/crawler-policy"
     },
     "amazon-kendra": {
         "operator": "Amazon",


### PR DESCRIPTION
I operate the AIWebIndex crawler and I am correcting my own entry. Four fields
were wrong or unverifiable. Every correction can be checked at a public URL.

| Field | Was | Now |
|---|---|---|
| `operator` | `Lyrenth that builds an AI-readable index of web content for AI systems` (malformed, not a link) | `[Lyrenth](https://lyrenth.com)` |
| `respect` | `Unclear at this time.` | `[Yes](https://lyrenth.com/crawler-policy)` |
| `function` | `AI Data Providers` | `AI Search Crawlers` |
| `frequency` | `Unclear at this time.` | one request per domain every 2 seconds, slower where `Crawl-delay` is set |

**On the category.** We do not sell datasets and we do not train foundation
models on crawled content. We index public pages and serve them back to agents
as readable text, with attribution and a link to the source. Sites that consume
this list are rendering `AI Data Providers` as "data scrapers and resellers",
which is why this field is the one that matters. `AI Search Crawlers` is an
existing value in this file, currently used by Applebot, ExaSearchBot,
LinkupBot, Amzn-SearchBot and AzureAI-SearchBot.

**On verification.** The entry recorded none. There are three:

- IP ranges: https://lyrenth.com/bot/ip-ranges.json (22 prefixes, same format as `gptbot.json`)
- Forward-confirmed reverse DNS under `lyrenth.com` for every one of those addresses
- Web Bot Auth (RFC 9421) signatures, key directory at https://api.lyrenth.com/.well-known/http-message-signatures-directory

**I am not asking to be removed from the list or made harder to block.** The
user-agent token is unchanged, so `robots.txt`, `.htaccess`, the nginx, haproxy
and lighttpd configs and the `Caddyfile` are all byte-identical after this
change. Only `table-of-bot-metrics.md` moves. Our own policy page publishes the
robots.txt rule for blocking us: https://lyrenth.com/crawler-policy

Only `robots.json` is touched, per the Contributing note in the README.