### PR TITLE
Add KI-Zugangsindex to Related resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ file on-the-fly.
 
 - [Bot Ledger](https://farrelldan.github.io/ai-bot-directory/): free, static directory of verified AI crawlers with a one-click `robots.txt` and `llms.txt` generator. No signup required.
 
+- [KI-Zugangsindex](https://peppe1337.github.io/ki-zugangsindex/): open dataset on how widely this kind of blocking is actually deployed in the German (`.de`) web, measured on a fixed panel of 600 domains so the same sites can be re-checked over time. First measurement 2026-08-25: of the domains serving a parseable `robots.txt`, 32.8% in the top 300 (77/235) disallow at least one of GPTBot, OAI-SearchBot, ClaudeBot or PerplexityBot, against 14.8% (31/210) of domains outside the top 50,000. All 600 raw responses and the measurement code are included.
+
 ## Contributing
 
 A note about contributing: updates should be added/made to `robots.json`. A GitHub action will then generate the updated `robots.txt`, `table-of-bot-metrics.md`, `.htaccess` and `nginx-block-ai-bots.conf`.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ file on-the-fly.
 
 - [Bot Ledger](https://farrelldan.github.io/ai-bot-directory/): free, static directory of verified AI crawlers with a one-click `robots.txt` and `llms.txt` generator. No signup required.
 
-- [KI-Zugangsindex](https://peppe1337.github.io/ki-zugangsindex/): open dataset on how widely this kind of blocking is actually deployed in the German (`.de`) web, measured on a fixed panel of 600 domains so the same sites can be re-checked over time. First measurement 2026-08-25: of the domains serving a parseable `robots.txt`, 32.8% in the top 300 (77/235) disallow at least one of GPTBot, OAI-SearchBot, ClaudeBot or PerplexityBot, against 14.8% (31/210) of domains outside the top 50,000. All 600 raw responses and the measurement code are included.
+- [KI-Zugangsindex](https://peppe1337.github.io/ki-zugangsindex/): open dataset on how widely this kind of blocking is actually deployed in the German (`.de`) web, measured on a fixed panel of 600 domains so the same sites can be re-checked over time.
 
 ## Contributing
 


### PR DESCRIPTION
This adds one line to the `### Related` section, in the same spirit as the Bot Ledger entry.

**What it is:** an open dataset measuring how widely the blocking this repo enables is actually deployed in the German (`.de`) web. A fixed panel of 600 `.de` domains is checked for whether AI crawlers are allowed to fetch `/` according to `robots.txt`. The panel does not change between measurements, so repeated runs measure the same sites rather than a moving target.

**First measurement (2026-08-25),** of the domains that served a parseable `robots.txt`:

| | Top 300 `.de` | 300 `.de` outside the top 50,000 |
|---|---|---|
| Disallows ≥1 of GPTBot / OAI-SearchBot / ClaudeBot / PerplexityBot | 77 / 235 = 32.8% | 31 / 210 = 14.8% |

Blocking is concentrated among large publishers and retailers, not among small sites.

**Why it might be useful here:** this repo tells operators *how* to block; the dataset is evidence about *who actually does*, for a language region I could not find covered elsewhere. The Reuters Institute study includes Germany but covers 15 news publishers for 2023 only; what was missing is a German panel beyond news publishers and beyond the top ranks that gets repeated.

**Caveats, stated plainly:**
- There is currently **one** measurement point. It is a panel built for a time series, not yet a time series.
- It measures what `robots.txt` *says*, not whether crawlers obey it.
- Bot names are taken from this repo's list, among others.

All 600 raw `robots.txt` responses and the full measurement code are in the repo (MIT for code, data under CC BY 4.0). No signup, no tracking, static pages.

Happy to drop this if it is out of scope for `### Related` — no hard feelings.