### PR TITLE
Add KimiBot, Kimi-SearchBot and MistralAI-Training

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -637,12 +637,26 @@
         "frequency": "Unclear at this time.",
         "description": "Kangaroo Bot is used by the company Kangaroo LLM to download data to train AI models tailored to Australian language and culture. More info can be found at https://knownagents.com/agents/kangaroo-bot"
     },
+    "Kimi-SearchBot": {
+        "operator": "[Moonshot AI](https://www.moonshot.ai)",
+        "respect": "[Yes](https://www.kimi.ai/policies/kimi-crawlers)",
+        "function": "AI Search Crawlers",
+        "frequency": "No information provided.",
+        "description": "Kimi-SearchBot powers Kimi's search features: it analyzes pages for relevance and builds the search index. Documented by Moonshot AI at https://www.kimi.ai/policies/kimi-crawlers"
+    },
     "Kimi-User": {
         "operator": "Moonshot AI that fetches web content on behalf of users interacting with Kimi",
         "respect": "Unclear at this time.",
         "function": "AI Assistants",
         "frequency": "Unclear at this time.",
         "description": "Kimi-User is a web crawler operated by Moonshot AI that fetches web content on behalf of users interacting with Kimi. When a user asks Kimi to summarize an article or ans\u2026 More info can be found at https://knownagents.com/agents/kimi-user"
+    },
+    "KimiBot": {
+        "operator": "[Moonshot AI](https://www.moonshot.ai)",
+        "respect": "[Yes](https://www.kimi.ai/policies/kimi-crawlers)",
+        "function": "AI Data Scrapers",
+        "frequency": "No information provided.",
+        "description": "KimiBot crawls content potentially used to train Kimi's foundation models. Documented by Moonshot AI at https://www.kimi.ai/policies/kimi-crawlers"
     },
     "KlaviyoAIBot": {
         "operator": "[Klaviyo](https://www.klaviyo.com)",
@@ -748,6 +762,13 @@
         "function": "AI Assistants",
         "frequency": "Unhinged, more than 1 per second.",
         "description": "As per their documentation, \"The Meta-WebIndexer crawler navigates the web to improve Meta AI search result quality for users. In doing so, Meta analyzes online content to enhance the relevance and accuracy of Meta AI. Allowing Meta-WebIndexer in your robots.txt file helps us cite and link to your content in Meta AI's responses.\""
+    },
+    "MistralAI-Training": {
+        "operator": "[Mistral AI](https://mistral.ai)",
+        "respect": "[Yes](https://docs.mistral.ai/robots/)",
+        "function": "AI Data Scrapers",
+        "frequency": "No information provided.",
+        "description": "MistralAI-Training crawls web content to build training datasets. Documented by Mistral at https://docs.mistral.ai/robots/"
     },
     "MistralAI-User": {
         "operator": "Mistral",


### PR DESCRIPTION
Three crawlers that the list is missing, each documented by the vendor itself.

| Bot | Vendor documentation | Note |
|---|---|---|
| `KimiBot` | [kimi.ai/policies/kimi-crawlers](https://www.kimi.ai/policies/kimi-crawlers) | "Crawls content potentially used to train Kimi's foundation models" |
| `Kimi-SearchBot` | [kimi.ai/policies/kimi-crawlers](https://www.kimi.ai/policies/kimi-crawlers) | "Analyzes pages for relevance and builds the search index" |
| `MistralAI-Training` | [docs.mistral.ai/robots](https://docs.mistral.ai/robots/) | "Crawls web content to build training datasets" |

Moonshot AI documents three crawlers and the list currently has one (`Kimi-User`). Mistral documents three and the list has two (`MistralAI-User`, `MistralAI-Index`).

Generated files regenerated with `python3 code/robots.py --convert`. The seven failing tests in `code/tests.py` also fail on a clean `main` and are unrelated to this change.

### How these were found

They came out of a survey of the `robots.txt` of 79 Dutch news sites, where I collected user-agent names publishers block that are not on this list, then checked each one against the vendor's own documentation. Ten of the 79 sites were already blocking the two Kimi crawlers.

### Names I deliberately did not add

Same survey, but they did not survive verification. Recording them here so nobody has to repeat the work:

- **`Coherebot`** — this is a placeholder in Cohere's own [example robots.txt](https://docs.cohere.com/docs/cohere-web-crawlers). Cohere states there that it does not operate a crawler for training. Nine Dutch public broadcasters block it anyway, apparently copied from that documentation page.
- **`KimiCrawler`, `MoonshotBot`, `MoonSpider`** — not in Moonshot's documentation.
- **`MistralBot`** — not in Mistral's documentation.
- **`GrokBot`, `xAI-Grok`, `Grok-DeepSearch`** — xAI publishes no crawler documentation page, and [its own robots.txt](https://x.ai/robots.txt) does not name them. Several independent reports say Grok's retrieval traffic arrives with an ordinary Safari user-agent from rotating residential IPs, so a robots.txt entry would not match anything. Happy to open a separate issue if the project wants to track undocumented agents like this.
- **`SalamandraVLM`, `ZenphonyBot`, `micro-crawl`, `TalarionSearchBot`** — no vendor documentation found.

### One I found but am not proposing

OpenAI documents a fourth crawler, `OAI-AdsBot`, at [developers.openai.com/api/docs/bots](https://developers.openai.com/api/docs/bots). It "validates the safety of web pages submitted as ads on ChatGPT" — the analogue of `AdsBot-Google`. Since this list is used as a block list, adding it would mean site owners silently lose the ability to have ads pointing at their pages approved. That seemed like a call for the maintainers rather than something to slip into a PR, so I have left it out and am mentioning it here instead.