### PR TITLE
Add AI Access Checker to additional resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,3 +110,4 @@ But even if you don't use Cloudflare's hard block, their list of [verified bots]
 - [Blockin' bots on Netlify](https://www.jeremiak.com/blog/block-bots-netlify-edge-functions/) by Jeremia Kimelman
 - [Blocking AI web crawlers](https://underlap.org/blocking-ai-web-crawlers) by Glyn Normington
 - [Block AI Bots from Crawling Websites Using Robots.txt](https://originality.ai/ai-bot-blocking) by Jonathan Gillham, Originality.AI
+- [AI Access Checker: see which AI crawlers a site's robots.txt allows or blocks](https://www.greadme.com/ai-access-checker) by Saar Twito, Greadme


### PR DESCRIPTION
Adds a link under "Additional resources" to a free checker that reads a site's robots.txt, llms.txt, noindex and snippet rules and reports which AI crawlers can access and read it. No account or signup; it's a quick way to verify that a robots.txt built from this repo actually blocks what you intended.

I'm the author. If the resources list is meant for articles only, feel free to close — I understand the project's independence stance.