### PR TITLE
Add OAI-AdsBot

### DIFF
--- a/robots.json
+++ b/robots.json
@@ -812,6 +812,13 @@
         "frequency": "Unclear at this time.",
         "description": "Nova Act is an AI agent created by Amazon that can use a web browser. It can intelligently navigate and interact with websites to complete multi-step tasks on behalf of a\u2026 More info can be found at https://knownagents.com/agents/novaact"
     },
+    "OAI-AdsBot": {
+        "operator": "[OpenAI](https://openai.com)",
+        "respect": "Unclear at this time.",
+        "function": "Validates and targets ads on ChatGPT.",
+        "frequency": "Only when a page is submitted as an ad.",
+        "description": "OAI-AdsBot visits the landing page of a page submitted as an ad on ChatGPT, to check it against OpenAI's policies and, per OpenAI, to \"determine when it's most relevant to show the ad to users\". OpenAI states it only visits pages submitted as ads and that the data is not used to train foundation models. Documented at https://developers.openai.com/api/docs/bots"
+    },
     "OAI-SearchBot": {
         "operator": "[OpenAI](https://openai.com)",
         "respect": "[Yes](https://platform.openai.com/docs/bots)",


### PR DESCRIPTION
Adds `OAI-AdsBot`, the fourth crawler OpenAI documents at
https://developers.openai.com/api/docs/bots. Raised in #277; opening it
separately as requested.

Two things from OpenAI's own page that I have put in the fields rather than
leave to the reader, because both cut against a simple "block it":

- **The page does not say OAI-AdsBot obeys robots.txt**, and gives no disallow
  example, while it does for the other three. I have therefore set `respect` to
  "Unclear at this time." rather than the `Yes` that GPTBot, ChatGPT-User and
  OAI-SearchBot carry here.
- **OpenAI states the data is not used to train foundation models**, and that
  the crawler only visits pages someone submits as an ad.

What makes it belong on this list is the other half of the same paragraph:
content from the landing page is also used to "determine when it's most
relevant to show the ad to users". That is content use, not safety validation.

Worth flagging for anyone who copies this list wholesale: because the crawler
only visits pages submitted as ads, blocking it never stops an uninvited crawl.
It stops your own ad from being approved. That is a real trade-off for a
publisher, and different in kind from the rest of the list.

Only `robots.json` is changed; the other files are regenerated automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0141w8LsSMs7AHbon2ySf84n
